### PR TITLE
Changed type annotation of numOdds

### DIFF
--- a/pages/07-modules.md
+++ b/pages/07-modules.md
@@ -60,7 +60,7 @@ necessarily need to do the following in real life.
 import List exposing (length, partition)
 import Tuple
 
-numOdds : List number -> Int
+numOdds : List Int -> Int
 numOdds = 
     let
         odd n = n % 2 == 1


### PR DESCRIPTION
Type annotation must be List Int -> Int
The previous List number -> Int gave a type mismatch due to (%)'s type annotation (Int -> Int -> Int)