### PR TITLE
Add link to elm community resources

### DIFF
--- a/pages/01-introduction.md
+++ b/pages/01-introduction.md
@@ -32,7 +32,8 @@ person such as yourself will be able to follow along and learn Elm.
 The [elm-discuss mailing list](https://groups.google.com/forum/#!forum/elm-discuss) 
 is a great place to ask
 questions if you're feeling stuck. People there are extremely nice,
-patient and understanding to newbies.
+patient and understanding to newbies. You can find other ways to connect at the
+[Elm Community](http://elm-lang.org/community) page.
 
 So what's Elm?
 ------------------


### PR DESCRIPTION
I'd prefer the text to only point people to the elm community page in general, and not specifically mention the mailing list. However, I decided not to delete reference to the mailing page because simply adding a reference to the elm community page seems more likely to get accepted and merged.