### PR TITLE
Own types typos

### DIFF
--- a/pages/08-making-our-own-types-and-typeclasses.md
+++ b/pages/08-making-our-own-types-and-typeclasses.md
@@ -74,7 +74,7 @@ constructors.
 > Circle
 <function> : Float -> Float -> Float -> Shape
 > Rectangle
-<function> : Float -> Float -> Float -> Shape
+<function> : Float -> Float -> Float -> Float -> Shape
 ```
 
 Cool, so value constructors are functions like everything else. Who
@@ -112,8 +112,8 @@ them and everything. If we want a list of concentric circles with
 different radii, we can do this.
 
 ```elm
-> List.map (Circle 10 20) [4,5,6,6]
-[Circle 10.0 20.0 4.0,Circle 10.0 20.0 5.0,Circle 10.0 20.0 6.0,Circle 10.0 20.0 6.0] : List Shape
+> List.map (Circle 10 20) [4,5,6,7]
+[Circle 10.0 20.0 4.0,Circle 10.0 20.0 5.0,Circle 10.0 20.0 6.0,Circle 10.0 20.0 7.0] : List Shape
 ```
 
 Our data type is good, although it could be better. Let's make an
@@ -1016,9 +1016,9 @@ treeElem : comparable -> Tree comparable -> Bool
 treeElem x t = case t of
     EmptyTree -> False
     (Node a left right) ->
-    if x == a then True
-    else if x < a then treeElem x left
-    else treeElem x right
+        if x == a then True
+        else if x < a then treeElem x left
+        else treeElem x right
 ```
 
 All we had to do was write up the previous paragraph in code. Let's have


### PR DESCRIPTION
I think the indentation of the function treeElem should be improved.
It gave me an error when I pasted the code into the repl.
